### PR TITLE
Ensure entry slugs fit in a slug field. Fixes #35

### DIFF
--- a/andablog/migrations/0004_shorten_entry_title.py
+++ b/andablog/migrations/0004_shorten_entry_title.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import time
+from django.db import migrations, models
+
+
+# The new, maximum length of titles.
+TITLE_LENGTH = 255
+
+
+def truncate_entry_titles(apps, schema_editor):
+    """This function will truncate the values of Entry.title so they are
+    255 characters or less.
+    """
+    Entry = apps.get_model("andablog", "Entry")
+
+    for entry in Entry.objects.all():
+        # Truncate to 255 characters (or less) but keep whole words intact.
+        while len(entry.title) > TITLE_LENGTH:
+            entry.title = ' '.join(entry.title.split()[:-1])
+        entry.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('andablog', '0003_auto_20150826_2353'),
+    ]
+
+    operations = [
+        migrations.RunPython(truncate_entry_titles)
+    ]

--- a/andablog/migrations/0005_auto_20151017_1747.py
+++ b/andablog/migrations/0005_auto_20151017_1747.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('andablog', '0004_shorten_entry_title'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='entry',
+            name='slug',
+            field=models.SlugField(unique=True, editable=False, max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='entry',
+            name='title',
+            field=models.CharField(max_length=255),
+        ),
+    ]

--- a/andablog/models.py
+++ b/andablog/models.py
@@ -41,8 +41,10 @@ class Entry(TimeStampedModel):
         to any duplicate slugs.
 
         """
-        # Restrict slugs to 50 chars, and don't let them end in a dash.
-        self.slug = slugify(self.title)[:50].strip('-')
+        # Restrict slugs to 50 chars, but don't split mid-word
+        self.slug = slugify(self.title)
+        while len(self.slug) > 50:
+            self.slug = '-'.join(self.slug.split('-')[:-1])
 
         # Is the same slug as another entry?
         if Entry.objects.filter(slug=self.slug).exclude(id=self.id).exists():

--- a/andablog/models.py
+++ b/andablog/models.py
@@ -35,6 +35,16 @@ class Entry(TimeStampedModel):
     def get_absolute_url(self):
         return reverse('andablog:entrydetail', args=[self.slug])
 
+    def _insert_timestamp(self, value, max_length=50):
+        """Appends a timestamp integer to the given value, yet ensuring the
+        result is less than the specified max_length.
+        """
+        timestamp = str(int(time.time()))
+        value = "{}-{}".format(value, timestamp)
+        if len(value) > max_length:
+            value = '-'.join([value[:-len(timestamp)], timestamp])
+        return value
+
     def _slugify_title(self):
         """Slugify the Entry title, but ensure it's less than 50 characters.
         This method also ensures that a slug is unique by appending a timestamp
@@ -49,11 +59,7 @@ class Entry(TimeStampedModel):
         # Is the same slug as another entry?
         if Entry.objects.filter(slug=self.slug).exclude(id=self.id).exists():
             # Append time to differentiate, but keep total length < 50 chars.
-            timestamp = str(int(time.time()))
-            slug = "{}-{}".format(self.slug, timestamp)
-            if len(slug) > 50:
-                slug = '-'.join([self.slug[:-len(timestamp)], timestamp])
-            self.slug = slug
+            self.slug = self._insert_timestamp(self.slug, max_length=50)
 
     def save(self, *args, **kwargs):
         self._slugify_title()

--- a/andablog/models.py
+++ b/andablog/models.py
@@ -18,8 +18,8 @@ class Entry(TimeStampedModel):
     Represents a blog Entry.
     Uses TimeStampModel to provide created and modified fields
     """
-    title = models.CharField(max_length=500)
-    slug = models.SlugField(unique=True, editable=False)
+    title = models.CharField(max_length=255)
+    slug = models.SlugField(max_length=255, unique=True, editable=False)
     content = MarkupField()
     is_published = models.BooleanField(default=False)
     published_timestamp = models.DateTimeField(blank=True, null=True, editable=False)

--- a/andablog/models.py
+++ b/andablog/models.py
@@ -35,31 +35,31 @@ class Entry(TimeStampedModel):
     def get_absolute_url(self):
         return reverse('andablog:entrydetail', args=[self.slug])
 
-    def _insert_timestamp(self, value, max_length=50):
-        """Appends a timestamp integer to the given value, yet ensuring the
+    def _insert_timestamp(self, slug, max_length=255):
+        """Appends a timestamp integer to the given slug, yet ensuring the
         result is less than the specified max_length.
         """
         timestamp = str(int(time.time()))
-        value = "{}-{}".format(value, timestamp)
-        if len(value) > max_length:
-            value = '-'.join([value[:-len(timestamp)], timestamp])
-        return value
+        ts_len = len(timestamp) + 1
+        while len(slug) + ts_len > max_length:
+            slug = '-'.join(slug.split('-')[:-1])
+        slug = '-'.join([slug, timestamp])
+        return slug
 
     def _slugify_title(self):
-        """Slugify the Entry title, but ensure it's less than 50 characters.
-        This method also ensures that a slug is unique by appending a timestamp
-        to any duplicate slugs.
-
+        """Slugify the Entry title, but ensure it's less than the maximum
+        number of characters. This method also ensures that a slug is unique by
+        appending a timestamp to any duplicate slugs.
         """
-        # Restrict slugs to 50 chars, but don't split mid-word
+        # Restrict slugs to their maximum number of chars, but don't split mid-word
         self.slug = slugify(self.title)
-        while len(self.slug) > 50:
+        while len(self.slug) > 255:
             self.slug = '-'.join(self.slug.split('-')[:-1])
 
         # Is the same slug as another entry?
         if Entry.objects.filter(slug=self.slug).exclude(id=self.id).exists():
-            # Append time to differentiate, but keep total length < 50 chars.
-            self.slug = self._insert_timestamp(self.slug, max_length=50)
+            # Append time to differentiate.
+            self.slug = self._insert_timestamp(self.slug)
 
     def save(self, *args, **kwargs):
         self._slugify_title()

--- a/andablog/models.py
+++ b/andablog/models.py
@@ -35,12 +35,26 @@ class Entry(TimeStampedModel):
     def get_absolute_url(self):
         return reverse('andablog:entrydetail', args=[self.slug])
 
-    def save(self, *args, **kwargs):
-        self.slug = slugify(self.title)
+    def _slugify_title(self):
+        """Slugify the Entry title, but ensure it's less than 50 characters.
+        This method also ensures that a slug is unique by appending a timestamp
+        to any duplicate slugs.
+
+        """
+        # Restrict slugs to 50 chars, and don't let them end in a dash.
+        self.slug = slugify(self.title)[:50].strip('-')
+
         # Is the same slug as another entry?
         if Entry.objects.filter(slug=self.slug).exclude(id=self.id).exists():
-            # Append time to differentiate
-            self.slug = "{}-{}".format(self.slug, int(time.time()))
+            # Append time to differentiate, but keep total length < 50 chars.
+            timestamp = str(int(time.time()))
+            slug = "{}-{}".format(self.slug, timestamp)
+            if len(slug) > 50:
+                slug = '-'.join([self.slug[:-len(timestamp)], timestamp])
+            self.slug = slug
+
+    def save(self, *args, **kwargs):
+        self._slugify_title()
 
         # Time to publish?
         if not self.published_timestamp and self.is_published:

--- a/andablog/tests/test_models.py
+++ b/andablog/tests/test_models.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from django.test import TestCase
-from django.utils.text import slugify
 from django.utils import timezone
 
 from andablog import models
@@ -22,7 +21,30 @@ class TestEntryModel(TestCase):
 
     def test_slug_creation(self):
         """The slug field should automatically get set from the title during post creation"""
-        self.assertEqual(self.entry.slug, slugify(self.entry.title))
+        self.assertEqual(self.entry.slug, 'first-post')
+
+    def test_slug_creation_on_long_titles(self):
+        """The slug field should be limited to 50 chars even if the title is longer."""
+        self.entry.title = "Here's a really long title, for testing slug character restrictions"
+        self.entry.save()
+        self.assertEqual(self.entry.slug, 'heres-a-really-long-title-for-testing-slug-charact')
+
+    def test_long_slugs_should_not_end_with_a_dash(self):
+        """The slug should not end with a dash."""
+        self.entry.title = "Here's a really long title, for testing slug charac this gets excluded"
+        self.entry.save()
+        self.assertEqual(self.entry.slug, 'heres-a-really-long-title-for-testing-slug-charac')
+
+    def test_duplicate_long_slugs_should_get_a_timestamp(self):
+        """If a long title has a shortened slug that is a duplicate, it should have a timestamp"""
+        self.entry.title = "Here's a really long title, for testing slug character restrictions"
+        self.entry.save()
+
+        duplicate_entry = models.Entry.objects.create(title=self.entry.title, content=self.entry.content)
+
+        self.assertNotEqual(self.entry.slug, duplicate_entry.slug)
+        # This is not ideal, but a portion of the original slug is in the duplicate
+        self.assertIn(self.entry.slug[:25], duplicate_entry.slug)
 
     def test_new_duplicate(self):
         """The slug value should automatically be made unique if the slug is taken"""

--- a/andablog/tests/test_models.py
+++ b/andablog/tests/test_models.py
@@ -28,13 +28,13 @@ class TestEntryModel(TestCase):
         """The slug field should be limited to 50 chars even if the title is longer."""
         self.entry.title = SafeText("Here's a really long title, for testing slug character restrictions")
         self.entry.save()
-        self.assertEqual(self.entry.slug, 'heres-a-really-long-title-for-testing-slug-charact')
+        self.assertEqual(self.entry.slug, 'heres-a-really-long-title-for-testing-slug')
 
-    def test_long_slugs_should_not_end_with_a_dash(self):
-        """The slug should not end with a dash."""
-        self.entry.title = SafeText("Here's a really long title, for testing slug charac this gets excluded")
+    def test_long_slugs_should_not_get_split_midword(self):
+        """The slug should not get split mid-word."""
+        self.entry.title = SafeText("Please tell me where everyone is getting their assumptions about me?")
         self.entry.save()
-        self.assertEqual(self.entry.slug, 'heres-a-really-long-title-for-testing-slug-charac')
+        self.assertEqual(self.entry.slug, 'please-tell-me-where-everyone-is-getting-their')
 
     def test_duplicate_long_slugs_should_get_a_timestamp(self):
         """If a long title has a shortened slug that is a duplicate, it should have a timestamp"""

--- a/andablog/tests/test_models.py
+++ b/andablog/tests/test_models.py
@@ -3,6 +3,7 @@
 
 from django.test import TestCase
 from django.utils import timezone
+from django.utils.safestring import SafeText
 
 from andablog import models
 
@@ -25,19 +26,19 @@ class TestEntryModel(TestCase):
 
     def test_slug_creation_on_long_titles(self):
         """The slug field should be limited to 50 chars even if the title is longer."""
-        self.entry.title = "Here's a really long title, for testing slug character restrictions"
+        self.entry.title = SafeText("Here's a really long title, for testing slug character restrictions")
         self.entry.save()
         self.assertEqual(self.entry.slug, 'heres-a-really-long-title-for-testing-slug-charact')
 
     def test_long_slugs_should_not_end_with_a_dash(self):
         """The slug should not end with a dash."""
-        self.entry.title = "Here's a really long title, for testing slug charac this gets excluded"
+        self.entry.title = SafeText("Here's a really long title, for testing slug charac this gets excluded")
         self.entry.save()
         self.assertEqual(self.entry.slug, 'heres-a-really-long-title-for-testing-slug-charac')
 
     def test_duplicate_long_slugs_should_get_a_timestamp(self):
         """If a long title has a shortened slug that is a duplicate, it should have a timestamp"""
-        self.entry.title = "Here's a really long title, for testing slug character restrictions"
+        self.entry.title = SafeText("Here's a really long title, for testing slug character restrictions")
         self.entry.save()
 
         duplicate_entry = models.Entry.objects.create(title=self.entry.title, content=self.entry.content)


### PR DESCRIPTION
Here's a first attempt at resolving #35. It does the following:

* moves the slugify code into a method outside of `save`, `_slugify_title`.
* limits slugs to 50 characters (ensuring there's no trailing dash)
* uses the existing technique to prevent duplicate slugs (adding a timestamp to the end), but does so in a way that still ensures the slug is less than 50 chars.
* adds a test case for each of the above.

Let me know what you think. I'm open to revising any of this.